### PR TITLE
Only remove default vhost if it is not used

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,6 +14,8 @@
 - name: remove default vhost
   become: yes
   command: rabbitmqctl delete_vhost /
+  when:
+    - rabbitmq_vhost != '/'
 
 - name: remove guest user
   become: yes


### PR DESCRIPTION
I'm trying to use this role to deploy a legacy app that has no choice but to use the default vhost `/`.

With this change the vhost won't get deleted when the handlers get run at the end of my play. This allows a user of this role to specify the vhost var as `rabbitmq_vhost: '/'` without the default vhost getting removed.