### PR TITLE
Call set_user_tags for newly created user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,5 @@ rabbitmq_user_perm_conf: '.*'
 rabbitmq_user_perm_write: '.*'
 
 rabbitmq_user_perm_read: '.*'
+
+rabbitmq_user_tags:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,3 +25,8 @@
 - name: configure user
   become: yes
   command: "rabbitmqctl set_permissions -p {{ rabbitmq_vhost }} {{ rabbitmq_user_name }} '{{ rabbitmq_user_perm_conf }}' '{{ rabbitmq_user_perm_write }}' '{{ rabbitmq_user_perm_read }}'"
+
+- name: set user tags
+  become: yes
+  command: "rabbitmqctl set_user_tags {{ rabbitmq_user_name }} {{ rabbitmq_user_tags | join(' ') }}"
+  when: rabbitmq_user_tags

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,4 +54,6 @@
     - rabbitmq_user_name != None
     - rabbitmq_user_name != ''
     - rabbitmq_user_name not in rabbitmq_users.stdout
-  notify: configure user
+  notify:
+    - configure user
+    - set user tags


### PR DESCRIPTION
With this change a newly created user can be assigned any tags by specifying them as a list in the `rabbitmq_user_tags` variable.

If the variable is left empty the role doesn't touch the user and everything behaves like before this change.